### PR TITLE
Signaling and quoted hashed passwords

### DIFF
--- a/lib/tor/control.rb
+++ b/lib/tor/control.rb
@@ -190,7 +190,7 @@ module Tor
     # @raise  [AuthenticationError] if authentication failed
     def authenticate(cookie = nil)
       cookie ||= @options[:cookie]
-      send(:send_line, cookie ? "AUTHENTICATE #{cookie}" : "AUTHENTICATE")
+      send(:send_line, cookie ? "AUTHENTICATE \"#{cookie}\"" : "AUTHENTICATE")
       case reply = read_reply
         when '250 OK' then @authenticated = true
         else raise AuthenticationError.new(reply)


### PR DESCRIPTION
Dear Bendiken:

I implemented Tor::Controller#signal , as I wrote you before.

Also I modified the Tor::Controller#authenticate method to quote the password (I couldn't find a test for cookie authentication, so I'm not sure if it breaks existing functionality...)

Thanks
