### PR TITLE
Tor.version fix for new Tor version

### DIFF
--- a/lib/tor.rb
+++ b/lib/tor.rb
@@ -65,6 +65,8 @@ module Tor
   def self.version
     if available? && `#{program_path} --version` =~ /Tor v(\d+)\.(\d+)\.(\d+)\.(\d+)/
       [$1, $2, $3, $4].join('.')
+    elsif available? && `#{program_path} --version` =~ /Tor version (\d+)\.(\d+)\.(\d+)\.(\d+)/
+      [$1, $2, $3, $4].join('.')
     end
   end
 


### PR DESCRIPTION
With the last version of Tor the version string has changed.

`$ tor --version`
Output:
**Tor version 0.2.4.20 (git-0d50b03673670de6).**
