### PR TITLE
Fix authenticate for cookie

### DIFF
--- a/lib/tor/control.rb
+++ b/lib/tor/control.rb
@@ -190,7 +190,7 @@ module Tor
     # @raise  [AuthenticationError] if authentication failed
     def authenticate(cookie = nil)
       cookie ||= @options[:cookie]
-      send(:send_line, cookie ? "AUTHENTICATE \"#{cookie}\"" : "AUTHENTICATE")
+      send(:send_line, cookie ? "AUTHENTICATE #{cookie}" : "AUTHENTICATE")
       case reply = read_reply
         when '250 OK' then @authenticated = true
         else raise AuthenticationError.new(reply)


### PR DESCRIPTION
The authenticate method for cookie does not need double quotes.
See for example here: https://stem.torproject.org/faq.html
With the double quotes around cookie I get:
`515 Authentication failed: Wrong length on authentication cookie.`