### PR TITLE
fix DNSEL to use the new service

### DIFF
--- a/spec/dnsel_spec.rb
+++ b/spec/dnsel_spec.rb
@@ -40,27 +40,9 @@ describe Tor::DNSEL do
     end
   end
 
-  describe "Tor::DNSEL.dnsname without options" do
+  describe "Tor::DNSEL.dnsname" do
     it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4') == '4.3.2.1.53.8.8.8.8.ip-port.exitlist.torproject.org'
-    end
-  end
-
-  describe "Tor::DNSEL.dnsname with a target port" do
-    it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :port => 25) == '4.3.2.1.25.8.8.8.8.ip-port.exitlist.torproject.org'
-    end
-  end
-
-  describe "Tor::DNSEL.dnsname with a target IP address" do
-    it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4') == '4.3.2.1.53.4.4.8.8.ip-port.exitlist.torproject.org'
-    end
-  end
-
-  describe "Tor::DNSEL.dnsname with a target IP address and port" do
-    it "returns the correct DNS name" do
-      expect Tor::DNSEL.dnsname('1.2.3.4', :addr => '8.8.4.4', :port => 25) == '4.3.2.1.25.4.4.8.8.ip-port.exitlist.torproject.org'
+      expect Tor::DNSEL.dnsname('1.2.3.4') == '4.3.2.1.dnsel.torproject.org'
     end
   end
 


### PR DESCRIPTION
The Tor Project has changed the way their Tor Exit Node List project works. Instead of requiring you to submit a "target" ip address (and optionally port), it now only requires the reversed ip of the potential exit node.

This PR attempts to make those changes.

More info can be found on their blog: https://blog.torproject.org/changes-tor-exit-list-service

I'm curious to know if beyond the included tests there's anything else we can do to ensure this works the way we expect it to.


Thanks!